### PR TITLE
tickets/DM-30717: Added the first tests of the SAL AuthList feature.

### DIFF
--- a/Jenkinsfile.quick
+++ b/Jenkinsfile.quick
@@ -223,12 +223,38 @@ pipeline {
                 }//JavaEvents
             }//parallel
         }//RunJavaMessagingTests
+        stage('RunAuthlist') {
+             when {
+                not {
+                    expression {
+                        return params.Generate
+                    }
+                }
+            }
+            steps {
+                sh label: 'CppAuthList', script: '#!/bin/bash \n' + 'source ' + _home + '/.bash_profile \n' + 'set -x \n' +
+                'echo ========= Move to robotframework_SAL directory ========= \n' +
+                'echo cd ' + _home + '/trunk/robotframework_SAL \n' +
+                'cd ' + _home + '/trunk/robotframework_SAL \n' +
+                'echo ========= Execute SAL C++ AuthList tests ========= \n' +
+                'robot --outputdir ' + _home + '/trunk/Reports --variable ContInt:true -e skipped --skiponfailure TSS* --skiponfailure DM* ' +
+                    '--variable SALVersion:' + SAL_Version + ' --variable SALInstall:' + _home + '/trunk/ts_sal ' +
+                    '--variable OpenspliceRelease:\'OpenSplice HDE Release\' ' +
+                    '--variable OpenspliceVersion:' + _ospl_version + ' --variable OpenspliceDate:' + _ospl_date +
+                    ' --variable MavenVersion:' + MavenVersion + ' --variable XMLVersion:' + XML_Version +
+                    ' --variable Build_Number:' + Build_Param +
+                    ' --variable MvnVersion:"Apache Maven ' + _mvn_version + '" --variable PythonVersion:\'Python ' + _python_version + '\' ' +
+                    '--name CppAuthList --output CppAuthList ' +
+                    _home + '/trunk/robotframework_SAL/AuthList/CPP/Script_AuthList.robot \n' +
+                'exit 0'
+            }
+        }//AuthList
     }//stages
     post { 
         always {
             //Process Robot-Framework results.
             sh label: 'Results', script: '#!/bin/bash \n' + 'echo "# Check for output files."\n' +
-            'declare -a outputs=(VALIDATE.xml CombinedCppTelemetry.xml CombinedCppEvents.xml CombinedJavaTelemetry.xml CombinedJavaEvents.xml)\n' + 
+            'declare -a outputs=(VALIDATE.xml CombinedCppTelemetry.xml CombinedCppEvents.xml CombinedJavaTelemetry.xml CombinedJavaEvents.xml CppAuthList.xml)\n' + 
             'echo ${outputs[@]}\n' +
             'i=0\n echo i=$i\n' + 'for item in "${outputs[@]}"; do\n' +
             '\tif test -f ' + _home + '/trunk/Reports/$item; then array[$i]=' + _home + '/trunk/Reports/$item; else echo ' +

--- a/Jenkinsfile.salxml
+++ b/Jenkinsfile.salxml
@@ -312,6 +312,53 @@ pipeline {
                 }//JavaEvents
             }//parallel
         }//RunJavaMessagingTests
+        stage('Run AuthList Tests') {
+            when {
+                expression {
+                    return params.Messaging
+                }
+            }
+            parallel {
+                stage('CppAuthlist') {
+                    steps {
+                        sh label: 'CppAuthList', script: '#!/bin/bash \n' + 'source ' + _home + '/.bash_profile \n' + 'set -x \n' +
+                        'echo ========= Move to robotframework_SAL directory ========= \n' +
+                        'echo cd ' + _home + '/trunk/robotframework_SAL \n' +
+                        'cd ' + _home + '/trunk/robotframework_SAL \n' +
+                        'echo ========= Execute SAL C++ AuthList tests ========= \n' +
+                        'robot --outputdir ' + _home + '/trunk/Reports --variable ContInt:true -e skipped --skiponfailure TSS* --skiponfailure DM* ' +
+                            '--variable SALVersion:' + SAL_Version + ' --variable SALInstall:' + _home + '/trunk/ts_sal ' +
+                            '--variable OpenspliceRelease:\'OpenSplice HDE Release\' ' +
+                            '--variable OpenspliceVersion:' + _ospl_version + ' --variable OpenspliceDate:' + _ospl_date +
+                            ' --variable MavenVersion:' + MavenVersion + ' --variable XMLVersion:' + XML_Version +
+                            ' --variable Build_Number:' + Build_Param +
+                            ' --variable MvnVersion:"Apache Maven ' + _mvn_version + '" --variable PythonVersion:\'Python ' + _python_version + '\' ' +
+                            '--name CppAuthList --output CppAuthList ' +
+                            '-A ' + _home + '/trunk/robotframework_SAL/CppAuthList_Tests.list \n' +
+                        'exit 0'
+                    }
+                }//CppAuthList
+                stage('JavaAuthlist') {
+                    steps {
+                        sh label: 'JavaAuthList', script: '#!/bin/bash \n' + 'source ' + _home + '/.bash_profile \n' + 'set -x \n' +
+                        'echo ========= Move to robotframework_SAL directory ========= \n' +
+                        'echo cd ' + _home + '/trunk/robotframework_SAL \n' +
+                        'cd ' + _home + '/trunk/robotframework_SAL \n' +
+                        'echo ========= Execute SAL C++ AuthList tests ========= \n' +
+                        'robot --outputdir ' + _home + '/trunk/Reports --variable ContInt:true -e skipped --skiponfailure TSS* --skiponfailure DM* ' +
+                            '--variable SALVersion:' + SAL_Version + ' --variable SALInstall:' + _home + '/trunk/ts_sal ' +
+                            '--variable OpenspliceRelease:\'OpenSplice HDE Release\' ' +
+                            '--variable OpenspliceVersion:' + _ospl_version + ' --variable OpenspliceDate:' + _ospl_date +
+                            ' --variable MavenVersion:' + MavenVersion + ' --variable XMLVersion:' + XML_Version +
+                            ' --variable Build_Number:' + Build_Param +
+                            ' --variable MvnVersion:"Apache Maven ' + _mvn_version + '" --variable PythonVersion:\'Python ' + _python_version + '\' ' +
+                            '--name JavaAuthList --output JavaAuthList ' +
+                            '-A ' + _home + '/trunk/robotframework_SAL/JavaAuthList_Tests.list \n' +
+                        'exit 0'
+                    }
+                }//JavaAuthlist
+            }//parallel
+        }//RunAuthListTests
         stage('Push RPMs to Nexus3') {
             when {
                 expression { 
@@ -417,7 +464,7 @@ pipeline {
         always {
             //Process Robot-Framework results.
             sh label: 'Results', script: '#!/bin/bash \n' + 'echo "# Check for output files."\n' +
-            'declare -a outputs=(VALIDATE.xml AUXTEL.xml MAINTEL.xml CombinedCppTelemetry.xml CombinedCppEvents.xml CombinedJavaTelemetry.xml CombinedJavaEvents.xml) \n' + 
+            'declare -a outputs=(VALIDATE.xml AUXTEL.xml MAINTEL.xml CombinedCppTelemetry.xml CombinedCppEvents.xml CombinedJavaTelemetry.xml CombinedJavaEvents.xml CppAuthList.xml JavaAuthList.xml ) \n' + 
             'echo ${outputs[@]}\n' +
             'i=0\n echo i=$i\n' + 'for item in "${outputs[@]}"; do\n' +
             '\tif test -f ' + _home + '/trunk/Reports/$item; then array[$i]=' + _home + '/trunk/Reports/$item; else echo ' +

--- a/SALGEN/ATCamera_salgenerator.robot
+++ b/SALGEN/ATCamera_salgenerator.robot
@@ -215,7 +215,7 @@ Salgen ATCamera IDL
 Salgen ATCamera Java
     [Documentation]    Generate Java libraries.
     [Tags]    java
-    ${output}=    Run Process    ${SALHome}/bin/salgenerator    ${subSystem}    sal    java    shell=True    cwd=${SALWorkDir}    stdout=${EXECDIR}${/}${subSystem}_stdout.txt    stderr=${EXECDIR}${/}${subSystem}_stderr.txt
+    ${output}=    Run Process    ${SALHome}/bin/salgenerator    ${subSystem}    sal    java    version\=${Build_Number}${MavenVersion}    shell=True    cwd=${SALWorkDir}    stdout=${EXECDIR}${/}${subSystem}_stdout.txt    stderr=${EXECDIR}${/}${subSystem}_stderr.txt
     Log Many    ${output.stdout}    ${output.stderr}
     Should Not Contain    ${output.stdout}    ERROR : Failed to generate Java DDS types
     Should Contain    ${output.stdout}    SAL generator - ${SALVersion}
@@ -236,6 +236,11 @@ Salgen ATCamera Java
     File Should Exist    ${SALWorkDir}/${subSystem}/java/sal_${subSystem}.idl
     File Should Exist    ${SALWorkDir}/${subSystem}/java/saj_${subSystem}_types.jar
     File Should Exist    ${SALWorkDir}/${subSystem}/java/sal_${subSystem}.idl
+
+Verify ATCamera Java AuthList Interfaces
+    [Documentation]    Verify the Java Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/java/src/testAuthList.sh
 
 Salgen ATCamera Lib
     [Documentation]    Generate the SAL shared library for ${subSystem}

--- a/SALGEN/ATHeaderService_salgenerator.robot
+++ b/SALGEN/ATHeaderService_salgenerator.robot
@@ -101,7 +101,7 @@ Salgen ATHeaderService IDL
 Salgen ATHeaderService Java
     [Documentation]    Generate Java libraries.
     [Tags]    java
-    ${output}=    Run Process    ${SALHome}/bin/salgenerator    ${subSystem}    sal    java    shell=True    cwd=${SALWorkDir}    stdout=${EXECDIR}${/}${subSystem}_stdout.txt    stderr=${EXECDIR}${/}${subSystem}_stderr.txt
+    ${output}=    Run Process    ${SALHome}/bin/salgenerator    ${subSystem}    sal    java    version\=${Build_Number}${MavenVersion}    shell=True    cwd=${SALWorkDir}    stdout=${EXECDIR}${/}${subSystem}_stdout.txt    stderr=${EXECDIR}${/}${subSystem}_stderr.txt
     Log Many    ${output.stdout}    ${output.stderr}
     Should Not Contain    ${output.stdout}    ERROR : Failed to generate Java DDS types
     Should Contain    ${output.stdout}    SAL generator - ${SALVersion}
@@ -112,6 +112,11 @@ Salgen ATHeaderService Java
     File Should Exist    ${SALWorkDir}/${subSystem}/java/sal_${subSystem}.idl
     File Should Exist    ${SALWorkDir}/${subSystem}/java/saj_${subSystem}_types.jar
     File Should Exist    ${SALWorkDir}/${subSystem}/java/sal_${subSystem}.idl
+
+Verify ATHeaderService Java AuthList Interfaces
+    [Documentation]    Verify the Java Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/java/src/testAuthList.sh
 
 Salgen ATHeaderService Lib
     [Documentation]    Generate the SAL shared library for ${subSystem}

--- a/SALGEN/ATMCS_salgenerator.robot
+++ b/SALGEN/ATMCS_salgenerator.robot
@@ -390,6 +390,11 @@ Verify ATMCS C++ Event Interfaces
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_nasmyth2Brake_send
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_nasmyth2Brake_log
 
+Verify ATMCS C++ AuthList Interfaces
+    [Documentation]    Verify the C++ Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/testAuthList.sh
+
 Salgen ATMCS LabVIEW
     [Documentation]    Generate ${subSystem} low-level LabView interfaces.
     [Tags]    labview

--- a/SALGEN/ATPneumatics_salgenerator.robot
+++ b/SALGEN/ATPneumatics_salgenerator.robot
@@ -314,6 +314,11 @@ Verify ATPneumatics C++ Event Interfaces
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_m2SetPressure_send
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_m2SetPressure_log
 
+Verify ATPneumatics C++ AuthList Interfaces
+    [Documentation]    Verify the C++ Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/testAuthList.sh
+
 Salgen ATPneumatics LabVIEW
     [Documentation]    Generate ${subSystem} low-level LabView interfaces.
     [Tags]    labview

--- a/SALGEN/ATPtg_salgenerator.robot
+++ b/SALGEN/ATPtg_salgenerator.robot
@@ -492,6 +492,11 @@ Verify ATPtg C++ Event Interfaces
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_pointData_send
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_pointData_log
 
+Verify ATPtg C++ AuthList Interfaces
+    [Documentation]    Verify the C++ Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/testAuthList.sh
+
 Salgen ATPtg Lib
     [Documentation]    Generate the SAL shared library for ${subSystem}
     [Tags]    lib

--- a/SALGEN/CCCamera_salgenerator.robot
+++ b/SALGEN/CCCamera_salgenerator.robot
@@ -265,7 +265,7 @@ Salgen CCCamera IDL
 Salgen CCCamera Java
     [Documentation]    Generate Java libraries.
     [Tags]    java
-    ${output}=    Run Process    ${SALHome}/bin/salgenerator    ${subSystem}    sal    java    shell=True    cwd=${SALWorkDir}    stdout=${EXECDIR}${/}${subSystem}_stdout.txt    stderr=${EXECDIR}${/}${subSystem}_stderr.txt
+    ${output}=    Run Process    ${SALHome}/bin/salgenerator    ${subSystem}    sal    java    version\=${Build_Number}${MavenVersion}    shell=True    cwd=${SALWorkDir}    stdout=${EXECDIR}${/}${subSystem}_stdout.txt    stderr=${EXECDIR}${/}${subSystem}_stderr.txt
     Log Many    ${output.stdout}    ${output.stderr}
     Should Not Contain    ${output.stdout}    ERROR : Failed to generate Java DDS types
     Should Contain    ${output.stdout}    SAL generator - ${SALVersion}
@@ -298,6 +298,11 @@ Salgen CCCamera Java
     File Should Exist    ${SALWorkDir}/${subSystem}/java/sal_${subSystem}.idl
     File Should Exist    ${SALWorkDir}/${subSystem}/java/saj_${subSystem}_types.jar
     File Should Exist    ${SALWorkDir}/${subSystem}/java/sal_${subSystem}.idl
+
+Verify CCCamera Java AuthList Interfaces
+    [Documentation]    Verify the Java Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/java/src/testAuthList.sh
 
 Salgen CCCamera Lib
     [Documentation]    Generate the SAL shared library for ${subSystem}

--- a/SALGEN/CCHeaderService_salgenerator.robot
+++ b/SALGEN/CCHeaderService_salgenerator.robot
@@ -101,7 +101,7 @@ Salgen CCHeaderService IDL
 Salgen CCHeaderService Java
     [Documentation]    Generate Java libraries.
     [Tags]    java
-    ${output}=    Run Process    ${SALHome}/bin/salgenerator    ${subSystem}    sal    java    shell=True    cwd=${SALWorkDir}    stdout=${EXECDIR}${/}${subSystem}_stdout.txt    stderr=${EXECDIR}${/}${subSystem}_stderr.txt
+    ${output}=    Run Process    ${SALHome}/bin/salgenerator    ${subSystem}    sal    java    version\=${Build_Number}${MavenVersion}    shell=True    cwd=${SALWorkDir}    stdout=${EXECDIR}${/}${subSystem}_stdout.txt    stderr=${EXECDIR}${/}${subSystem}_stderr.txt
     Log Many    ${output.stdout}    ${output.stderr}
     Should Not Contain    ${output.stdout}    ERROR : Failed to generate Java DDS types
     Should Contain    ${output.stdout}    SAL generator - ${SALVersion}
@@ -112,6 +112,11 @@ Salgen CCHeaderService Java
     File Should Exist    ${SALWorkDir}/${subSystem}/java/sal_${subSystem}.idl
     File Should Exist    ${SALWorkDir}/${subSystem}/java/saj_${subSystem}_types.jar
     File Should Exist    ${SALWorkDir}/${subSystem}/java/sal_${subSystem}.idl
+
+Verify CCHeaderService Java AuthList Interfaces
+    [Documentation]    Verify the Java Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/java/src/testAuthList.sh
 
 Salgen CCHeaderService Lib
     [Documentation]    Generate the SAL shared library for ${subSystem}

--- a/SALGEN/Guider_salgenerator.robot
+++ b/SALGEN/Guider_salgenerator.robot
@@ -204,6 +204,11 @@ Verify Guider C++ Event Interfaces
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_guidingStatus_send
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_guidingStatus_log
 
+Verify Guider C++ AuthList Interfaces
+    [Documentation]    Verify the C++ Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/testAuthList.sh
+
 Salgen Guider Lib
     [Documentation]    Generate the SAL shared library for ${subSystem}
     [Tags]    lib

--- a/SALGEN/MTCamera_salgenerator.robot
+++ b/SALGEN/MTCamera_salgenerator.robot
@@ -265,7 +265,7 @@ Salgen MTCamera IDL
 Salgen MTCamera Java
     [Documentation]    Generate Java libraries.
     [Tags]    java
-    ${output}=    Run Process    ${SALHome}/bin/salgenerator    ${subSystem}    sal    java    shell=True    cwd=${SALWorkDir}    stdout=${EXECDIR}${/}${subSystem}_stdout.txt    stderr=${EXECDIR}${/}${subSystem}_stderr.txt
+    ${output}=    Run Process    ${SALHome}/bin/salgenerator    ${subSystem}    sal    java    version\=${Build_Number}${MavenVersion}    shell=True    cwd=${SALWorkDir}    stdout=${EXECDIR}${/}${subSystem}_stdout.txt    stderr=${EXECDIR}${/}${subSystem}_stderr.txt
     Log Many    ${output.stdout}    ${output.stderr}
     Should Not Contain    ${output.stdout}    ERROR : Failed to generate Java DDS types
     Should Contain    ${output.stdout}    SAL generator - ${SALVersion}
@@ -313,6 +313,11 @@ Salgen MTCamera Java
     File Should Exist    ${SALWorkDir}/${subSystem}/java/sal_${subSystem}.idl
     File Should Exist    ${SALWorkDir}/${subSystem}/java/saj_${subSystem}_types.jar
     File Should Exist    ${SALWorkDir}/${subSystem}/java/sal_${subSystem}.idl
+
+Verify MTCamera Java AuthList Interfaces
+    [Documentation]    Verify the Java Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/java/src/testAuthList.sh
 
 Salgen MTCamera Lib
     [Documentation]    Generate the SAL shared library for ${subSystem}

--- a/SALGEN/MTHeaderService_salgenerator.robot
+++ b/SALGEN/MTHeaderService_salgenerator.robot
@@ -101,7 +101,7 @@ Salgen MTHeaderService IDL
 Salgen MTHeaderService Java
     [Documentation]    Generate Java libraries.
     [Tags]    java
-    ${output}=    Run Process    ${SALHome}/bin/salgenerator    ${subSystem}    sal    java    shell=True    cwd=${SALWorkDir}    stdout=${EXECDIR}${/}${subSystem}_stdout.txt    stderr=${EXECDIR}${/}${subSystem}_stderr.txt
+    ${output}=    Run Process    ${SALHome}/bin/salgenerator    ${subSystem}    sal    java    version\=${Build_Number}${MavenVersion}    shell=True    cwd=${SALWorkDir}    stdout=${EXECDIR}${/}${subSystem}_stdout.txt    stderr=${EXECDIR}${/}${subSystem}_stderr.txt
     Log Many    ${output.stdout}    ${output.stderr}
     Should Not Contain    ${output.stdout}    ERROR : Failed to generate Java DDS types
     Should Contain    ${output.stdout}    SAL generator - ${SALVersion}
@@ -112,6 +112,11 @@ Salgen MTHeaderService Java
     File Should Exist    ${SALWorkDir}/${subSystem}/java/sal_${subSystem}.idl
     File Should Exist    ${SALWorkDir}/${subSystem}/java/saj_${subSystem}_types.jar
     File Should Exist    ${SALWorkDir}/${subSystem}/java/sal_${subSystem}.idl
+
+Verify MTHeaderService Java AuthList Interfaces
+    [Documentation]    Verify the Java Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/java/src/testAuthList.sh
 
 Salgen MTHeaderService Lib
     [Documentation]    Generate the SAL shared library for ${subSystem}

--- a/SALGEN/MTM1M3_salgenerator.robot
+++ b/SALGEN/MTM1M3_salgenerator.robot
@@ -652,6 +652,11 @@ Verify MTM1M3 C++ Event Interfaces
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_inclinometerSettings_send
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_inclinometerSettings_log
 
+Verify MTM1M3 C++ AuthList Interfaces
+    [Documentation]    Verify the C++ Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/testAuthList.sh
+
 Salgen MTM1M3 Lib
     [Documentation]    Generate the SAL shared library for ${subSystem}
     [Tags]    lib

--- a/SALGEN/MTM2_salgenerator.robot
+++ b/SALGEN/MTM2_salgenerator.robot
@@ -346,6 +346,11 @@ Verify MTM2 C++ Event Interfaces
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_temperatureOffset_send
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_temperatureOffset_log
 
+Verify MTM2 C++ AuthList Interfaces
+    [Documentation]    Verify the C++ Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/testAuthList.sh
+
 Salgen MTM2 LabVIEW
     [Documentation]    Generate ${subSystem} low-level LabView interfaces.
     [Tags]    labview

--- a/SALGEN/MTMount_salgenerator.robot
+++ b/SALGEN/MTMount_salgenerator.robot
@@ -412,6 +412,11 @@ Verify MTMount C++ Event Interfaces
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_warning_send
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_warning_log
 
+Verify MTMount C++ AuthList Interfaces
+    [Documentation]    Verify the C++ Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/testAuthList.sh
+
 Salgen MTMount LabVIEW
     [Documentation]    Generate ${subSystem} low-level LabView interfaces.
     [Tags]    labview

--- a/SALGEN/MTPtg_salgenerator.robot
+++ b/SALGEN/MTPtg_salgenerator.robot
@@ -492,6 +492,11 @@ Verify MTPtg C++ Event Interfaces
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_pointData_send
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_pointData_log
 
+Verify MTPtg C++ AuthList Interfaces
+    [Documentation]    Verify the C++ Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/testAuthList.sh
+
 Salgen MTPtg Lib
     [Documentation]    Generate the SAL shared library for ${subSystem}
     [Tags]    lib

--- a/SALGEN/MTRotator_salgenerator.robot
+++ b/SALGEN/MTRotator_salgenerator.robot
@@ -270,10 +270,15 @@ Verify MTRotator C++ Event Interfaces
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_commandableByDDS_send
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_commandableByDDS_log
 
+Verify MTRotator C++ AuthList Interfaces
+    [Documentation]    Verify the C++ Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/testAuthList.sh
+
 Salgen MTRotator Java
     [Documentation]    Generate Java libraries.
     [Tags]    java
-    ${output}=    Run Process    ${SALHome}/bin/salgenerator    ${subSystem}    sal    java    shell=True    cwd=${SALWorkDir}    stdout=${EXECDIR}${/}${subSystem}_stdout.txt    stderr=${EXECDIR}${/}${subSystem}_stderr.txt
+    ${output}=    Run Process    ${SALHome}/bin/salgenerator    ${subSystem}    sal    java    version\=${Build_Number}${MavenVersion}    shell=True    cwd=${SALWorkDir}    stdout=${EXECDIR}${/}${subSystem}_stdout.txt    stderr=${EXECDIR}${/}${subSystem}_stderr.txt
     Log Many    ${output.stdout}    ${output.stderr}
     Should Not Contain    ${output.stdout}    ERROR : Failed to generate Java DDS types
     Should Contain    ${output.stdout}    SAL generator - ${SALVersion}
@@ -289,6 +294,11 @@ Salgen MTRotator Java
     File Should Exist    ${SALWorkDir}/${subSystem}/java/sal_${subSystem}.idl
     File Should Exist    ${SALWorkDir}/${subSystem}/java/saj_${subSystem}_types.jar
     File Should Exist    ${SALWorkDir}/${subSystem}/java/sal_${subSystem}.idl
+
+Verify MTRotator Java AuthList Interfaces
+    [Documentation]    Verify the Java Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/java/src/testAuthList.sh
 
 Salgen MTRotator Lib
     [Documentation]    Generate the SAL shared library for ${subSystem}

--- a/SALGEN/Script_salgenerator.robot
+++ b/SALGEN/Script_salgenerator.robot
@@ -151,6 +151,11 @@ Verify Script C++ Event Interfaces
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_state_send
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_state_log
 
+Verify Script C++ AuthList Interfaces
+    [Documentation]    Verify the C++ Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/testAuthList.sh
+
 Salgen Script Python
     [Documentation]    Generate Python libraries.
     [Tags]    python

--- a/SALGEN/Test_salgenerator.robot
+++ b/SALGEN/Test_salgenerator.robot
@@ -218,6 +218,11 @@ Verify Test C++ Event Interfaces
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_arrays_send
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_arrays_log
 
+Verify Test C++ AuthList Interfaces
+    [Documentation]    Verify the C++ Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/testAuthList.sh
+
 Salgen Test Python
     [Documentation]    Generate Python libraries.
     [Tags]    python
@@ -327,7 +332,7 @@ Salgen Test LabVIEW
 Salgen Test Java
     [Documentation]    Generate Java libraries.
     [Tags]    java
-    ${output}=    Run Process    ${SALHome}/bin/salgenerator    ${subSystem}    sal    java    shell=True    cwd=${SALWorkDir}    stdout=${EXECDIR}${/}${subSystem}_stdout.txt    stderr=${EXECDIR}${/}${subSystem}_stderr.txt
+    ${output}=    Run Process    ${SALHome}/bin/salgenerator    ${subSystem}    sal    java    version\=${Build_Number}${MavenVersion}    shell=True    cwd=${SALWorkDir}    stdout=${EXECDIR}${/}${subSystem}_stdout.txt    stderr=${EXECDIR}${/}${subSystem}_stderr.txt
     Log Many    ${output.stdout}    ${output.stderr}
     Should Not Contain    ${output.stdout}    ERROR : Failed to generate Java DDS types
     Should Contain    ${output.stdout}    SAL generator - ${SALVersion}
@@ -341,6 +346,11 @@ Salgen Test Java
     File Should Exist    ${SALWorkDir}/${subSystem}/java/sal_${subSystem}.idl
     File Should Exist    ${SALWorkDir}/${subSystem}/java/saj_${subSystem}_types.jar
     File Should Exist    ${SALWorkDir}/${subSystem}/java/sal_${subSystem}.idl
+
+Verify Test Java AuthList Interfaces
+    [Documentation]    Verify the Java Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/java/src/testAuthList.sh
 
 Salgen Test Lib
     [Documentation]    Generate the SAL shared library for ${subSystem}

--- a/SALGEN/WeatherStation_salgenerator.robot
+++ b/SALGEN/WeatherStation_salgenerator.robot
@@ -252,6 +252,11 @@ Verify WeatherStation C++ Event Interfaces
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_authList_send
     File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/sacpp_${subSystem}_authList_log
 
+Verify WeatherStation C++ AuthList Interfaces
+    [Documentation]    Verify the C++ Authlist files were properly created.
+    [Tags]    cpp
+    File Should Exist    ${SALWorkDir}/${subSystem}/cpp/src/testAuthList.sh
+
 Salgen WeatherStation Lib
     [Documentation]    Generate the SAL shared library for ${subSystem}
     [Tags]    lib

--- a/scripts/SalGen.sh
+++ b/scripts/SalGen.sh
@@ -278,6 +278,17 @@ function verifyCppEventInterfaces() {
 }
 
 
+function verifyCppAuthlistInterfaces() {
+    # Creates the test case to verify the expected
+    # C++ AuthList files were created.
+    echo "Verify $subSystemUp C++ AuthList Interfaces" >> $testSuite
+    echo "    [Documentation]    Verify the C++ Authlist files were properly created." >> $testSuite
+    echo "    [Tags]    cpp" >> $testSuite
+    echo "    File Should Exist    \${SALWorkDir}/\${subSystem}/cpp/src/testAuthList.sh" >> $testSuite
+    echo "" >> $testSuite
+}
+
+
 function salgenJava() {
     # Creates the salgenerator Java test case.
     #  Some CSCs have NO telemetry.
@@ -287,7 +298,7 @@ function salgenJava() {
     echo "Salgen $subSystemUp Java" >> $testSuite
     echo "    [Documentation]    Generate Java libraries." >> $testSuite
     echo "    [Tags]    java$skipped" >> $testSuite
-    echo "    \${output}=    Run Process    \${SALHome}/bin/salgenerator    \${subSystem}    sal    java    \
+    echo "    \${output}=    Run Process    \${SALHome}/bin/salgenerator    \${subSystem}    sal    java    version\\=\${Build_Number}\${MavenVersion}    \
 shell=True    cwd=\${SALWorkDir}    stdout=\${EXECDIR}\${/}\${subSystem}_stdout.txt    stderr=\${EXECDIR}\${/}\${subSystem}_stderr.txt" >> $testSuite
     echo "    Log Many    \${output.stdout}    \${output.stderr}" >> $testSuite
     echo "    Should Not Contain    \${output.stdout}    ERROR : Failed to generate Java DDS types" >> $testSuite
@@ -330,6 +341,17 @@ shell=True    cwd=\${SALWorkDir}    stdout=\${EXECDIR}\${/}\${subSystem}_stdout.
     echo "    Should Contain X Times    \${output.stdout}    [INFO] Finished at:    1" >> $testSuite
     echo "    @{files}=    List Directory    \${SALWorkDir}/maven" >> $testSuite
     echo "    File Should Exist    \${SALWorkDir}/maven/\${subSystem}-\${XMLVersion}_\${SALVersion}\${Build_Number}\${MavenVersion}/pom.xml" >> $testSuite
+    echo "" >> $testSuite
+}
+
+
+function verifyJavaAuthlistInterfaces() {
+    # Creates the test case to verify the expected
+    # Java AuthList files were created.
+    echo "Verify $subSystemUp Java AuthList Interfaces" >> $testSuite
+    echo "    [Documentation]    Verify the Java Authlist files were properly created." >> $testSuite
+    echo "    [Tags]    cpp" >> $testSuite
+    echo "    File Should Exist    \${SALWorkDir}/\${subSystem}/java/src/testAuthList.sh" >> $testSuite
     echo "" >> $testSuite
 }
 
@@ -748,6 +770,7 @@ function createTestSuite() {
         if [[ ${#eventArray[@]} -ne 0 ]]; then
             verifyCppEventInterfaces
         fi
+        verifyCppAuthlistInterfaces
     fi
     # Create and verify Python interfaces.
     if [[ ${rtlang[@]} =~ "SALPY" ]]; then
@@ -773,6 +796,7 @@ function createTestSuite() {
     # Create and verify Java interfaces.
     if [[ ${rtlang[@]} =~ "Java" ]]; then
         salgenJava
+        verifyJavaAuthlistInterfaces
     fi
     # Move/Generate the SAL libraries.
     salgenLib "${rtlang[@]}"


### PR DESCRIPTION
Added the version parameter to the Java salgenerator process.

Added the C++ AuthList tests to Jenkinsfile.quick.

Regenerated the test suites with the new AuthList checks.

Turns out the Script does not support the Java language, so there are no Java AuthList tests to run in the SAL/XML quick tests, Jenkinsfile.quick. Restructured the block to only run the C++ AuthList tests.

Added the AuthList tests to Jenkinsfile.salxml. They are run in a separate parallel stage block, after the messaging tests.